### PR TITLE
feat: handle HAL CAN transmit errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Not currently supported:
 
 ## Dependencies
 
+- C11 compiler.
 - 32 bit STM32 microcontroller.
 - ThreadX memory pool, thread, semaphore and queue services.
 - STM32 Hardware Abstraction Layer (HAL) CAN drivers.

--- a/inc/rtcan.h
+++ b/inc/rtcan.h
@@ -7,10 +7,11 @@
 #ifndef RTCAN_H
 #define RTCAN_H
 
+#include <stdatomic.h>
+#include <stdbool.h>
+
 #include "tx_api.h"
-
 #include "rtcan.h"
-
 #include "can.h"
 
 /*
@@ -27,7 +28,7 @@
 #endif
 
 #ifndef RTCAN_RX_MSG_POOL_SIZE
-    #define RTCAN_RX_MSG_POOL_SIZE 100 // default, number of items
+    #define RTCAN_RX_MSG_POOL_SIZE 1000 // default, number of items
 #endif
 
 #ifndef RTCAN_SUBSCRIBER_POOL_SIZE
@@ -117,7 +118,7 @@ typedef struct
 /*
  * queue sizing constants
  */
-#define RTCAN_TX_QUEUE_LENGTH    100
+#define RTCAN_TX_QUEUE_LENGTH    10
 #define RTCAN_TX_QUEUE_ITEM_SIZE (sizeof(rtcan_msg_t) / sizeof(ULONG))
 #define RTCAN_TX_QUEUE_SIZE      (RTCAN_TX_QUEUE_LENGTH * RTCAN_TX_QUEUE_ITEM_SIZE)
 
@@ -210,6 +211,11 @@ typedef struct
      */
     uint32_t err;
 
+    /**
+     * @brief   Flag for Rx service being ready
+     */
+    atomic_bool rx_ready;
+
 } rtcan_handle_t;
 
 /*
@@ -237,6 +243,9 @@ rtcan_status_t rtcan_subscribe(rtcan_handle_t* rtcan_h,
 
 rtcan_status_t rtcan_msg_consumed(rtcan_handle_t* rtcan_h,
                                   rtcan_msg_t* msg_ptr);
+
+rtcan_status_t rtcan_handle_hal_error(rtcan_handle_t* rtcan_h,
+                                      CAN_HandleTypeDef* can_h);
 
 uint32_t rtcan_get_error(rtcan_handle_t* rtcan_h);
 

--- a/src/rtcan.c
+++ b/src/rtcan.c
@@ -56,6 +56,7 @@ rtcan_status_t rtcan_init(rtcan_handle_t* rtcan_h,
 {
     rtcan_h->hcan = hcan;
     rtcan_h->err = RTCAN_ERROR_NONE;
+    rtcan_h->rx_ready = false;
 
     // threads
     void* stack_ptr = NULL;
@@ -178,17 +179,17 @@ rtcan_status_t rtcan_init(rtcan_handle_t* rtcan_h,
         ADD_ERROR_IF(tx_status != TX_SUCCESS, RTCAN_ERROR_INTERNAL, rtcan_h);
     }
 
-    // TODO: configure CAN filters (allow one through for test)
+    // TODO: configure CAN filters
     if (no_errors(rtcan_h))
     {
         CAN_FilterTypeDef filter;
         filter.FilterActivation = ENABLE;
         filter.FilterFIFOAssignment = CAN_FILTER_FIFO0;
-        filter.FilterIdHigh = 0x0100 << 5U;
-        filter.FilterIdLow = 0x0101 << 5U; // TODO: temporary test!
+        filter.FilterIdHigh = 0x0000 << 5U;
+        filter.FilterIdLow = 0x0000 << 5U;
         filter.FilterMaskIdHigh = 0x0000 << 5U;
         filter.FilterMaskIdLow = 0x0000 << 5U;
-        filter.FilterMode = CAN_FILTERMODE_IDLIST;
+        filter.FilterMode = CAN_FILTERMODE_IDMASK;
         filter.FilterScale = CAN_FILTERSCALE_16BIT;
         filter.FilterBank = 0;
 
@@ -581,14 +582,17 @@ rtcan_status_t rtcan_handle_rx_it(rtcan_handle_t* rtcan_h,
                                   const CAN_HandleTypeDef* can_h,
                                   const uint32_t rx_fifo)
 {
-    // ULONG queue_item = rx_fifo;
-
-    // UINT status = tx_queue_send(&rtcan_h->rx_notif_queue,
-    //                             (void*) &queue_item,
-    //                             TX_NO_WAIT);
+    if (!rtcan_h->rx_ready)
+    {
+        HAL_CAN_GetRxMessage(rtcan_h->hcan,
+                             rx_fifo,
+                             NULL,
+                             NULL);
+        return RTCAN_OK;
+    }
 
     // allocate message
-    rtcan_msg_t* msg_ptr;
+    rtcan_msg_t* msg_ptr = NULL;
 
     UINT tx_status = tx_block_allocate(&rtcan_h->rx_msg_pool,
                                        (void**) &msg_ptr,
@@ -668,6 +672,8 @@ static void rtcan_rx_thread_entry(ULONG input)
 
     while (1)
     {
+        rtcan_h->rx_ready = true;
+
         // wait for message
         rtcan_msg_t* msg_ptr;
 
@@ -715,6 +721,50 @@ static void rtcan_rx_thread_entry(ULONG input)
             }
         }
     }
+}
+
+//======================================================================== error
+
+/**
+ * @brief       Handles HAL CAN errors
+ * 
+ * @param[in]   rtcan_h     RTCAN handle
+ * @param[in]   can_h       CAN handle
+ */
+rtcan_status_t rtcan_handle_hal_error(rtcan_handle_t* rtcan_h,
+                                      CAN_HandleTypeDef* can_h)
+{
+    rtcan_status_t status = RTCAN_OK;
+
+    if (can_h == rtcan_h->hcan)
+    {
+        const uint32_t tx_errors[] = {
+            HAL_CAN_ERROR_TX_TERR0,
+            HAL_CAN_ERROR_TX_TERR1,
+            HAL_CAN_ERROR_TX_TERR2,
+            HAL_CAN_ERROR_TX_ALST0,
+            HAL_CAN_ERROR_TX_ALST1,
+            HAL_CAN_ERROR_TX_ALST2,
+        };
+
+        uint32_t error = HAL_CAN_GetError(rtcan_h->hcan);
+        bool error_handled = false;
+
+        for (uint32_t i = 0; i < sizeof(tx_errors)/sizeof(tx_errors[0]); i++)
+        {
+            if (error == tx_errors[i])
+            {
+                tx_semaphore_put(&rtcan_h->tx_mailbox_sem);
+                error_handled = true;
+                break;
+            }
+        }
+
+        // unhandled/unknown errors
+        ADD_ERROR_IF(!error_handled, RTCAN_ERROR_INTERNAL, rtcan_h);
+    }
+
+    return status;
 }
 
 //====================================================================== utility

--- a/src/rtcan.c
+++ b/src/rtcan.c
@@ -56,7 +56,7 @@ rtcan_status_t rtcan_init(rtcan_handle_t* rtcan_h,
 {
     rtcan_h->hcan = hcan;
     rtcan_h->err = RTCAN_ERROR_NONE;
-    rtcan_h->rx_ready = false;
+    atomic_store(&rtcan_h->rx_ready, true);
 
     // threads
     void* stack_ptr = NULL;
@@ -582,7 +582,7 @@ rtcan_status_t rtcan_handle_rx_it(rtcan_handle_t* rtcan_h,
                                   const CAN_HandleTypeDef* can_h,
                                   const uint32_t rx_fifo)
 {
-    if (!rtcan_h->rx_ready)
+    if (!atomic_load(&rtcan_h->rx_ready))
     {
         HAL_CAN_GetRxMessage(rtcan_h->hcan,
                              rx_fifo,
@@ -672,7 +672,7 @@ static void rtcan_rx_thread_entry(ULONG input)
 
     while (1)
     {
-        rtcan_h->rx_ready = true;
+        atomic_store(&rtcan_h->rx_ready, true);
 
         // wait for message
         rtcan_msg_t* msg_ptr;


### PR DESCRIPTION
### Changes
- If a CAN transmit error occurs, the Tx mailbox semaphore is incremented.
- Users must now call `rtcan_handle_hal_error()` in `HAL_CAN_ErrorCallback()`.

### Related Issue(s)
Fixes #10 
