### PR TITLE
Feat/id filter

### DIFF
--- a/src/rtcan.c
+++ b/src/rtcan.c
@@ -199,7 +199,7 @@ rtcan_status_t rtcan_start(rtcan_handle_t* rtcan_h)
     {
         if(rtcan_h->subscriber_map[i] != NULL)
         {
-            /* CAN ID found! */
+            /* Subscriber found! */
             can_id_list[number_ids] = rtcan_h->subscriber_map[i]->can_id;
             number_ids++;
 
@@ -219,7 +219,7 @@ rtcan_status_t rtcan_start(rtcan_handle_t* rtcan_h)
         filter.FilterMode = CAN_FILTERMODE_IDLIST;
         filter.FilterScale = CAN_FILTERSCALE_16BIT;    
 
-        /* Configure Filter IDs for each filter */
+        /* Configure Filter IDs for each filter bank */
         for(int i = 0; i < number_banks; i++)
         {
             filter.FilterIdHigh = can_id_list[4 * i] << 5U;


### PR DESCRIPTION
### Changes
- Add automatic CAN filter configuration using ID_List mode
  - The configuration is placed at the beginning of `rtcan_start()` function as the subscriber list is complete at that point.
  - Prior filter configuration, the can_ids are obtained and the total number of can_ids is calculated. This step might be improved by adding `first_hashmap_element` pointer and the `subscriber_counter` to `rtcan_handle_t` struct. Instead, we have to search linearly to be sure we don't miss any CAN_ID.
  - Finally, the number of filter banks is calculated and `HAL_CAN_ConfigFilter()` is called for each bank.

### Related Issue(s)
Closes #4 #5 

### Additional Notes
Any additional notes.
