### PR TITLE
Add the ability to send extended CAN frames

### DIFF
--- a/inc/rtcan.h
+++ b/inc/rtcan.h
@@ -112,6 +112,11 @@ typedef struct
      */
     volatile uint32_t reference_count;
 
+    /**
+     * @brief   Flag showing whether the message is an extended message
+     */
+     bool extended;
+
 } rtcan_msg_t;
 
 /*

--- a/src/rtcan.c
+++ b/src/rtcan.c
@@ -34,7 +34,8 @@ static void rtcan_rx_thread_entry(ULONG input);
 static rtcan_status_t transmit_internal(rtcan_handle_t* rtcan_h,
                                         uint32_t identifier,
                                         const uint8_t* data_ptr,
-                                        uint32_t data_length);
+                                        uint32_t data_length,
+                                        bool extended);
 
 
 //=============================================================== initialisation

--- a/src/rtcan.c
+++ b/src/rtcan.c
@@ -385,7 +385,7 @@ static void rtcan_tx_thread_entry(ULONG input)
             (void) transmit_internal(rtcan_h,
                                      message.identifier,
                                      message.data,
-                                     message.length
+                                     message.length,
                                      message.extended);
         }
         else

--- a/src/rtcan.c
+++ b/src/rtcan.c
@@ -338,7 +338,7 @@ static rtcan_status_t transmit_internal(rtcan_handle_t* rtcan_h,
             .DLC = data_length
         };
 
-        if(!extended){
+        if(extended){
             header.IDE = CAN_ID_EXT;
             header.ExtId = identifier;
         } else {

--- a/src/rtcan.c
+++ b/src/rtcan.c
@@ -310,11 +310,13 @@ rtcan_status_t rtcan_handle_tx_mailbox_callback(rtcan_handle_t* rtcan_h,
  * @param[in]   identifier      CAN standard identifier
  * @param[in]   data_ptr        Pointer to data to transmit
  * @param[in]   data_length     Length of data to transmit
+ * @param[in]   extended        Flag as to whether this is an extended frame to send
  */
 static rtcan_status_t transmit_internal(rtcan_handle_t* rtcan_h,
                                         uint32_t identifier,
                                         const uint8_t* data_ptr,
-                                        uint32_t data_length)
+                                        uint32_t data_length,
+                                        const bool extended)
 {
     if ((data_ptr == NULL) || (data_length == 0U))
     {
@@ -331,11 +333,17 @@ static rtcan_status_t transmit_internal(rtcan_handle_t* rtcan_h,
     {
         // create message
         CAN_TxHeaderTypeDef header = {
-            .IDE = CAN_ID_STD,
             .RTR = CAN_RTR_DATA,
-            .DLC = data_length,
-            .StdId = identifier,
+            .DLC = data_length
         };
+
+        if(!extended){
+            header.IDE = CAN_ID_EXT;
+            header.ExtId = identifier;
+        } else {
+            header.IDE = CAN_ID_STD;
+            header.StdId = identifier;
+        }
 
         // send it
         uint32_t tx_mailbox;
@@ -376,7 +384,8 @@ static void rtcan_tx_thread_entry(ULONG input)
             (void) transmit_internal(rtcan_h,
                                      message.identifier,
                                      message.data,
-                                     message.length);
+                                     message.length
+                                     message.extended);
         }
         else
         {


### PR DESCRIPTION
### Changes
- Add the ability to send CAN messages with an extended ID

### Additional Notes
**THIS CONTAINS BREAKING CHANGES.** The `rtcan_msg_t` struct has been changed to add an `extended` flag. This is then used to determine whether to send the message as a standard or extended message. If this is not defined, UB may occur.
